### PR TITLE
build: skip installation of devDependencies

### DIFF
--- a/.github/workflows/main_funcwws(staging).yml
+++ b/.github/workflows/main_funcwws(staging).yml
@@ -29,7 +29,8 @@ jobs:
         shell: pwsh
         run: |
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          npm install
+          npm install --production
+          npm audit
           npm run build --if-present
           npm run test --if-present
           popd


### PR DESCRIPTION
Skip installation of devDependencies as there are `jQuery` vulnerabilities related to a `diagrams` dependency. 

`diagrams@0.27.0 requires jquery@2.1.4 via space-pen@5.1.2`