### PR TITLE
fix: `infobase.graphql` now correctly uses `InfobaseFilter`

### DIFF
--- a/graphql/schema/Infobase.graphql
+++ b/graphql/schema/Infobase.graphql
@@ -23,5 +23,5 @@ type Infobase {
 }
 
 extend type Query {
-  Infobase(filter: allSitesAdjFilter): [Infobase]!
+  Infobase(filter: InfobaseFilter): [Infobase]!
 }


### PR DESCRIPTION
Fixes [AB#4501](https://dev.azure.com/HCPHAC/5346c868-3a60-4f97-aa76-49dc2380e734/_workitems/edit/4501)